### PR TITLE
Add tv support

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -11,6 +11,78 @@ def Start():
         ' %s ' % (L('PLUGIN_NAME')) ))
     Log.Info(strLog)
 
+class separateMediaPartsAgentMovies(Agent.TV_Shows):
+    """ Movies Plug-In """
+    name = L('PLUGIN_NAME') + ' (TV)'
+    languages = [Locale.Language.NoLanguage]
+    primary_provider = False
+    contributes_to = [
+        'com.plexapp.agents.themoviedb',
+        'com.plexapp.agents.thetvdb',
+        'com.plexapp.agents.none']
+
+    def search(self, results, media, lang, manual):
+        Log.Debug("---------------------BEGIN SEARCH---------------------")
+        
+        db_file = os.path.join(Prefs['library_path'],'Application Support/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db')
+        Log.Debug('Opening database file %s', db_file)
+        conn = sqlite3.connect(db_file, timeout=30000)
+
+        for season in media.seasons:
+            for episode in media.seasons[season].episodes:
+                for item in media.seasons[season].episodes[episode].items:
+                    localaudio.findAudio(item.parts, conn)
+
+        """ Return a dummy object to satisfy the framework """
+        results.Append(MetadataSearchResult(id='null', score=100))
+
+        conn.close()
+
+        Log.Debug("---------------------END SEARCH---------------------")
+
+    def update(self, metadata, media, lang, force):
+        Log.Debug("---------------------BEGIN UPDATE---------------------")
+        
+        # Clear out the title to ensure stale data doesn't clobber other agents' contributions.
+        metadata.title = None
+        
+        all_subs = {}
+        for season in media.seasons:
+            for episode in media.seasons[season].episodes:
+                for item in media.seasons[season].episodes[episode].items:
+                    for part in item.parts:
+                        for sub_stream in [x for x in part.streams if hasattr(x, 'url') and x.type == 3]:
+                            if not all_subs.has_key(sub_stream.url):
+                                file_name = sub_stream.url[7:]
+                                forced = ''
+                                default = ''
+                                (file, ext) = os.path.splitext(file_name)
+                                split_tag = file.rsplit('.', 1)
+                                if len(split_tag) > 1 and split_tag[1].lower() in ['forced', 'default'] :
+                                    if 'forced' == split_tag[1].lower():
+                                        forced = '1'
+                                    if 'default' == split_tag[1].lower():
+                                        default = '1'                        
+                                all_subs[sub_stream.url] = type('Subtitle', (object,), {})()
+                                all_subs[sub_stream.url].subtitleObject = Proxy.LocalFile(file_name, codec = sub_stream.codec, format = sub_stream.format, default = default, forced = forced)
+                                all_subs[sub_stream.url].language = Locale.Language.Match(sub_stream.language)
+                                all_subs[sub_stream.url].basename = os.path.basename(file_name)
+                                Log.Debug('Discovered subtitle file: ' + all_subs[sub_stream.url].basename + ' language: ' + all_subs[sub_stream.url].language + ' codec: ' + sub_stream.codec + ' format: ' + sub_stream.format + ' default: ' + default + ' forced: ' + forced)
+        
+        for season in media.seasons:
+            for episode in media.seasons[season].episodes:
+                for item in media.seasons[season].episodes[episode].items:
+                    for part in item.parts:
+                        arr = all_subs
+                        for subs_key in list(set(all_subs.keys()) - set([x.url for x in part.streams if hasattr(x, 'url') and x.type == 3])):
+                            sub = all_subs[subs_key]
+                            part.subtitles[sub.language][sub.basename] = sub.subtitleObject
+                            Log.Debug('Added subtitle file %s for item %s', subs_key, part.file)
+                
+
+        Log.Debug("---------------------END UPDATE---------------------")
+
+
 class separateMediaPartsAgentMovies(Agent.Movies):
     """ Movies Plug-In """
     name = L('PLUGIN_NAME') + ' (Movies)'
@@ -41,7 +113,6 @@ class separateMediaPartsAgentMovies(Agent.Movies):
         Log.Debug("---------------------END SEARCH---------------------")
 
     def update(self, metadata, media, lang, force):
-        
         Log.Debug("---------------------BEGIN UPDATE---------------------")
         
         # Clear out the title to ensure stale data doesn't clobber other agents' contributions.

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -3,7 +3,7 @@
 		"id": "ffmpeg_path",
 		"label": "Path to FFmpeg tool",
 		"type": "text",
-        "default": "/config/ffmpeg"
+        "default": "/usr/local/bin"
 	},
 	{
 		"id": "library_path",


### PR DESCRIPTION
This adds support for tv shows. Used the exact same way as movies where you just enable the agent in settings and refresh the metadata for the tv show. 

Changed the default path to /usr/local/bin since that is where you are installing it via the prepare_image.sh script
Signed-off-by: Luigi311 <luigi311.lg@gmail.com>